### PR TITLE
Updating timestamp for every delete operation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='mongo-connector',
       license="http://www.apache.org/licenses/LICENSE-2.0.html",
       platforms=["any"],
       classifiers=filter(None, classifiers.split("\n")),
-      install_requires=['pymongo >= 2.4', 'pysolr >= 3.1.0', 'elasticsearch'],
+      install_requires=['pymongo >= 2.4', 'pysolr >= 3.1.0', 'elasticsearch <= 1.3.1'],
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       package_data={
           'mongo_connector.doc_managers': ['schema.xml']


### PR DESCRIPTION
This is to address https://bugzilla.netiq.com/show_bug.cgi?id=932378 where an non-updated delete in oplog is blocking all further operations.

Addressed by making sure that the timestamp is updated for every delete. Since delete happens only during alert grooming, this is not a performance concern. Tested and found working fine.

Original patch is provided by varadhan.
